### PR TITLE
[feature] add manifest option to select perf event

### DIFF
--- a/examples/manifests/perfwrap.dhall
+++ b/examples/manifests/perfwrap.dhall
@@ -6,7 +6,9 @@ in      default
       ⫽ { name = "linuxperf-wrapped"
         , app =
               default.app
-            ⫽ { perfwrapper = Some { perfFreq.hertz = 1.0, perfLimit = +100000 }
+            ⫽ { perfwrapper = Some { perfFreq.hertz = 1.0,
+	    			     perfLimit = +100000,
+				     perfEvent = "instructions" }
               }
         }
     : types.Manifest

--- a/examples/manifests/perfwrap.json
+++ b/examples/manifests/perfwrap.json
@@ -5,7 +5,8 @@
       "perfFreq": {
         "hertz": 1
       },
-      "perfLimit": 100000
+      "perfLimit": 100000,
+      "perfEvent": "instructions"
     }
   }
 }

--- a/examples/manifests/perfwrap.yaml
+++ b/examples/manifests/perfwrap.yaml
@@ -4,3 +4,4 @@ app:
     perfFreq:
       hertz: 1
     perfLimit: 100000
+    perfEvent: "instructions"

--- a/hsnrm/dhall/types/manifest.dhall
+++ b/hsnrm/dhall/types/manifest.dhall
@@ -15,7 +15,10 @@ let Perfwrapper =
     -- the sensor. This upper bound should be set to a low positive value if
     -- no a-priori information is known; NRM will then use a recursive-doubling
     -- strategy to maintain its own bound.
-      { perfFreq : types.Frequency, perfLimit : Integer }
+      { perfFreq : types.Frequency
+      , perfLimit : Integer
+      , perfEvent : Text
+      }
 
 let Instrumentation =
     -- Activate LD_PRELOAD based `libnrm` instrumentation. The only attribute that configures this feature

--- a/hsnrm/src/NRM/Behavior.hs
+++ b/hsnrm/src/NRM/Behavior.hs
@@ -135,7 +135,9 @@ nrm _callTime (Req clientid msg) =
                     [ "-f",
                       Arg . show . U.fromHz
                         . Manifest.toFrequency
-                        $ Manifest.perfFreq p
+                        $ Manifest.perfFreq p,
+		      "-e",
+		      Arg . show $ Manifest.perfEvent p
                     ]
         modify $
           registerAwaiting

--- a/hsnrm/src/NRM/Types/Cmd.hs
+++ b/hsnrm/src/NRM/Types/Cmd.hs
@@ -152,7 +152,7 @@ addDownstreamCmdClient ::
 addDownstreamCmdClient c downstreamCmdClientID =
   c ^. #cmdCore . #manifest . #app . #perfwrapper & \case
     Nothing -> Nothing
-    (Just (Perfwrapper perfFreq perfLimit)) ->
+    (Just (Perfwrapper _ perfFreq perfLimit)) ->
       Just $
         c
           & #downstreamCmds


### PR DESCRIPTION
Reflect in manifest and command wrapping logic that the user can now
select the event that perf is monitoring.